### PR TITLE
fix(minestom): configure shadowJar so the loader gets a real JarInJar

### DIFF
--- a/minestom/build.gradle
+++ b/minestom/build.gradle
@@ -15,6 +15,34 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
 }
 
+shadowJar {
+    archiveFileName = 'luckperms-minestom.jarinjar'
+
+    relocate 'net.kyori.adventure', 'me.lucko.luckperms.lib.adventure'
+    relocate 'net.kyori.event', 'me.lucko.luckperms.lib.eventbus'
+    relocate 'com.github.benmanes.caffeine', 'me.lucko.luckperms.lib.caffeine'
+    relocate 'okio', 'me.lucko.luckperms.lib.okio'
+    relocate 'okhttp3', 'me.lucko.luckperms.lib.okhttp3'
+    relocate 'net.bytebuddy', 'me.lucko.luckperms.lib.bytebuddy'
+    relocate 'me.lucko.commodore', 'me.lucko.luckperms.lib.commodore'
+    relocate 'org.mariadb.jdbc', 'me.lucko.luckperms.lib.mariadb'
+    relocate 'com.mysql', 'me.lucko.luckperms.lib.mysql'
+    relocate 'org.postgresql', 'me.lucko.luckperms.lib.postgresql'
+    relocate 'com.zaxxer.hikari', 'me.lucko.luckperms.lib.hikari'
+    relocate 'com.mongodb', 'me.lucko.luckperms.lib.mongodb'
+    relocate 'org.bson', 'me.lucko.luckperms.lib.bson'
+    relocate 'redis.clients.jedis', 'me.lucko.luckperms.lib.jedis'
+    relocate 'io.nats.client', 'me.lucko.luckperms.lib.nats'
+    relocate 'com.rabbitmq', 'me.lucko.luckperms.lib.rabbitmq'
+    relocate 'org.apache.commons.pool2', 'me.lucko.luckperms.lib.commonspool2'
+    relocate 'ninja.leaping.configurate', 'me.lucko.luckperms.lib.configurate'
+    relocate 'org.yaml.snakeyaml', 'me.lucko.luckperms.lib.yaml'
+}
+
+artifacts {
+    archives shadowJar
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)


### PR DESCRIPTION
## Problem

The published `net.luckperms:minestom-loader:5.6-SNAPSHOT` jar carries **un-relocated** `net/kyori/adventure/**` and `net/bytebuddy/**` at the top level. That defeats the JarInJar isolation and pins every consumer (Titan, etc.) to LuckPerms' bundled (older) Adventure version, causing runtime failures like:

```
ServiceConfigurationError: net.kyori.adventure.text.logger.slf4j.ComponentLoggerProvider:
Provider net.minestom.server.adventure.provider.MinestomComponentLoggerProvider could not be instantiated
Caused by: java.lang.NoSuchMethodError:
'net.kyori.adventure.util.Buildable$Builder net.kyori.adventure.text.flattener.ComponentFlattener.toBuilder()'
  at net.minestom.server.adventure.provider.MinestomFlattenerProvider.<clinit>(MinestomFlattenerProvider.java:14)
  at net.minestom.server.adventure.provider.MinestomComponentLoggerProvider.<clinit>(...)
```

…on modern Minestom (`2026.05.17-1.21.11`).

## Root cause

`:minestom/build.gradle` declares the shadow plugin but has **no `shadowJar` configuration**:

- the output is `<name>-all.jar` (plain `.jar` extension), and
- it performs **no relocations**.

`:minestom/loader/build.gradle` then embeds the file via

```groovy
shadowJar {
    from { project(':minestom').tasks.shadowJar.archiveFile }
}
```

Because the input is a `.jar`, the Shadow plugin **unzips** it into the outer loader jar. Combined with the missing relocations, the loader jar ends up with `net/kyori/adventure/**` and `net/bytebuddy/**` at top level instead of carrying the inner shadow jar as a single resource.

## Fix

Mirror the `:velocity` shadowJar configuration (the closest analogue, since Velocity is also an Adventure-native platform):

- `archiveFileName = 'luckperms-minestom.jarinjar'` — Shadow does not unzip non-`.jar` inputs, so the loader's `from` copies the file verbatim; the name also matches the `JAR_NAME` constant in `MinestomLoader.java` that the `JarInJarClassLoader` looks up at runtime.
- The exact same relocate set as `:velocity` (adventure, event, caffeine, okio, okhttp3, bytebuddy, commodore, mariadb, mysql, postgresql, hikari, mongodb, bson, jedis, nats, rabbitmq, commons-pool2, configurate, snakeyaml).
- `artifacts { archives shadowJar }` so the loader picks up the configured archive.

## Effect

After this change, `minestom-loader-5.6-SNAPSHOT.jar` contains `luckperms-minestom.jarinjar` as a single resource (no top-level `net/kyori/adventure/**`) and the embedded LuckPerms platform runs inside its JarInJar-isolated classloader as designed — restoring the same isolation guarantees the Bukkit/Velocity loaders already provide.

## Test plan

- [ ] CI builds `:minestom:shadowJar` and `:minestom:loader:shadowJar` successfully.
- [ ] Inspect `minestom-loader-<ver>.jar`: top-level entries are `me/lucko/...`, `META-INF/`, `luckperms-minestom.jarinjar` — and **no** `net/kyori/adventure/**` or `net/bytebuddy/**` at the top level.
- [ ] `5.6-SNAPSHOT` deploys to the OLF snapshots repo.
- [ ] Downstream Titan smoke test: server boots, `LuckPermsProvider.get()` works, no Adventure `NoSuchMethodError` on Minestom `2026.05.17-1.21.11`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S76fk9ma5Szkf9r1W44RVP)_